### PR TITLE
[ADD] set the readme tables as tables without borders when generating the index.html file.

### DIFF
--- a/description2html/description2html.py
+++ b/description2html/description2html.py
@@ -246,6 +246,9 @@ class DescriptionToHtml(object):
                 else:
                     div_section['class'] = 'section oe_span12'
 
+            for table_tag in soup.findAll('table'):
+                table_tag['border'] = 0
+
             # for h2_tag in soup.findall('h2'):
             #     h2_tag.name = 'h3'
             #     h2_tag['class'] = 'oe_slogan'


### PR DESCRIPTION
When generating a index.html using `description2html` script with tables inside the README.rst file will put the tables with ugly border

This PR set this table format to without border to make the index.html file more appealing