### PR TITLE
[FIX] install odoo-instance: ImportError: No module named argcomplete

### DIFF
--- a/odoo-instance/install
+++ b/odoo-instance/install
@@ -1,4 +1,6 @@
 #!/bin/bash
+pip install argcomplete
+activate-global-python-argcomplete
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}"  )" && pwd  )"
 echo "alias odoo-instance='${DIR}/odoo-instance'" >> ${HOME}/.profile
 source ${HOME}/.profile


### PR DESCRIPTION
The odoo-instance scrpt depend on non standar argcomplete python package.
I will update the odoo-instance/install script to install the argcomplete
package there.