### PR TITLE
[ADD] clean_vim: script to clean vim history

### DIFF
--- a/clean_vim
+++ b/clean_vim
@@ -1,0 +1,5 @@
+#!/bin/bash
+rm -fv /root/.vimbackup/*
+rm -fv /root/.vimswap/*
+rm -fv /root/.vimundo/*
+rm -fv /root/.vimviews/*


### PR DESCRIPTION
This script clean up swap and temporal files that do not let you open your
files in vim. Used when containers stop abruptly or anything happen that close
vim abruptly.
