### PR TITLE
Git History Traslation between two Projects

### DIFF
--- a/git-history-migrate-branch.sh
+++ b/git-history-migrate-branch.sh
@@ -1,17 +1,14 @@
 #!/bin/bash
-
-# In order for this script to work you must:
-# - have git installed
-# - have hub installed
-# - configure your hub config file like:
-# ~/.config/hub
-
-# github.com:
-# - user: USER
-#   oauth_token: TOKEN
-#   protocol: https
-
-# TOKEN must be created in github / setting / Personal Access Tokens
+#/Usage: git-history-migrate-branch.sh module-list.txt instance-list.txt
+# module-list.txt is a list of odoo modules to be migrated from a project to
+# another. Must be one line per module.
+# instance-list.txt is a list of odoo projects which are affected by the
+# migration of this modules. Must be one line per instance.
+# token.txt must be located on $HOME_DIR
+# To create TOKEN you must go to github.com / Settings / Personal Access Token
+# and create a new one. Beware: TOKEN is like a password so it be kept safe.
+# Scripted by:
+# Humberto Arocha <hbto@vauxoo.com>
 
 HOME_DIR=/tmp
 ROOT_DIR=$HOME_DIR/branches

--- a/git-history-migrate-branch.sh
+++ b/git-history-migrate-branch.sh
@@ -13,8 +13,8 @@
 
 # TOKEN must be created in github / setting / Personal Access Tokens
 
-HOME_DIR=~/
-ROOT_DIR=~/xDev/git
+HOME_DIR=/tmp
+ROOT_DIR=$HOME_DIR/branches
 DST=account
 SRC=addons-vauxoo
 DEV=hbto
@@ -22,15 +22,58 @@ VER=8.0
 TOKEN=$(cat $HOME_DIR/token.txt)
 AUTH="\"""Authorization: token $TOKEN""\""
 
+echo "Moving inside $HOME_DIR Folder"
+cd $HOME_DIR
+
+if [ ! -d "$ROOT_DIR" ]; then
+    echo "Creating Folder $ROOT_DIR"
+    mkdir -p $ROOT_DIR
+fi
 
 echo "Moving inside $ROOT_DIR Folder"
 cd $ROOT_DIR
+
+for REPO in $SRC $DST
+do
+    echo "Checking if Folder $REPO already exists"
+    if [ -d "$REPO" ]; then
+        echo "Deleting Folder $REPO"
+        rm -rf $REPO
+    fi
+    echo "Cloning $REPO Project"
+    git clone git@github.com:Vauxoo/$REPO
+    cd $REPO
+    echo "Adding remote development branch to $REPO"
+    git remote add vauxoo-dev git@github.com:Vauxoo-dev/$REPO
+    echo "Switching back to $ROOT_DIR"
+    cd $ROOT_DIR
+done
+
+while IFS='' read -r REPO || [[ -n "$REPO" ]]; do
+    echo "Checking if Folder $REPO already exists"
+    if [ -d "$REPO" ]; then
+        echo "Deleting Folder $REPO"
+        rm -rf $REPO
+    fi
+    echo "Cloning $REPO Project"
+    git clone git@github.com:Vauxoo/$REPO
+    cd $REPO
+    echo "Adding remote development branch to $REPO"
+    git remote add vauxoo-dev git@github.com:Vauxoo-dev/$REPO
+    echo "Switching back to $ROOT_DIR"
+    cd $ROOT_DIR
+done < "$2"
 
 while IFS='' read -r MODULE || [[ -n "$MODULE" ]]; do
     echo "Module: $MODULE"
 
     echo "Moving inside $ROOT_DIR Folder"
     cd $ROOT_DIR
+
+    if [ -d "tmp-$SRC" ]; then
+        echo "Deleting Folder tmp-$SRC"
+        rm -rf tmp-$SRC
+    fi
 
     echo "Duplicating $SRC Folder to tmp-$SRC Folder"
     cp -r $SRC/ tmp-$SRC
@@ -102,7 +145,7 @@ while IFS='' read -r MODULE || [[ -n "$MODULE" ]]; do
     echo "Moving inside $ROOT_DIR Folder"
     cd $ROOT_DIR
 
-    echo "Moving inside $SRC to delete $MODULE module"
+    echo "Deleting  tmp-$SRC Because after being used is useless"
     rm -rf tmp-$SRC
 
     echo "Moving inside $SRC to migrate $MODULE"

--- a/git-history-migrate-branch.sh
+++ b/git-history-migrate-branch.sh
@@ -7,6 +7,10 @@
 # token.txt must be located on $HOME_DIR
 # To create TOKEN you must go to github.com / Settings / Personal Access Token
 # and create a new one. Beware: TOKEN is like a password so it be kept safe.
+
+# This could be helpful for rewriting history on project
+# https://developer.atlassian.com/blog/2015/08/grafting-earlier-history-with-git/
+
 # Scripted by:
 # Humberto Arocha <hbto@vauxoo.com>
 

--- a/git-history-migrate-branch.sh
+++ b/git-history-migrate-branch.sh
@@ -16,6 +16,8 @@
 
 HOME_DIR=/tmp
 ROOT_DIR=$HOME_DIR/branches
+USR_DST=vauxoo
+USR_SRC=hbto
 DST=account
 SRC=addons-vauxoo
 DEV=hbto
@@ -34,36 +36,46 @@ fi
 echo "Moving inside $ROOT_DIR Folder"
 cd $ROOT_DIR
 
-for REPO in $SRC $DST
-do
-    echo "Checking if Folder $REPO already exists"
-    if [ -d "$REPO" ]; then
-        echo "Deleting Folder $REPO"
-        rm -rf $REPO
-    fi
-    echo "Cloning $REPO Project"
-    git clone git@github.com:Vauxoo/$REPO
-    cd $REPO
-    echo "Adding remote development branch to $REPO"
-    git remote add vauxoo-dev git@github.com:Vauxoo-dev/$REPO
-    echo "Switching back to $ROOT_DIR"
-    cd $ROOT_DIR
-done
+echo "Checking if Folder $SRC already exists"
+if [ -d "$SRC" ]; then
+    echo "Deleting Folder $SRC"
+    rm -rf $SRC
+fi
+echo "Cloning $SRC Project"
+git clone git@github.com:$USR_SRC/$SRC
+cd $SRC
+echo "Adding remote development branch to $SRC"
+git remote add vauxoo-dev git@github.com:Vauxoo-dev/$SRC
+echo "Switching back to $ROOT_DIR"
+cd $ROOT_DIR
 
-while IFS='' read -r REPO || [[ -n "$REPO" ]]; do
-    echo "Checking if Folder $REPO already exists"
-    if [ -d "$REPO" ]; then
-        echo "Deleting Folder $REPO"
-        rm -rf $REPO
-    fi
-    echo "Cloning $REPO Project"
-    git clone git@github.com:Vauxoo/$REPO
-    cd $REPO
-    echo "Adding remote development branch to $REPO"
-    git remote add vauxoo-dev git@github.com:Vauxoo-dev/$REPO
-    echo "Switching back to $ROOT_DIR"
-    cd $ROOT_DIR
-done < "$2"
+echo "Checking if Folder $DST already exists"
+if [ -d "$DST" ]; then
+    echo "Deleting Folder $DST"
+    rm -rf $DST
+fi
+echo "Cloning $DST Project"
+git clone git@github.com:$USR_DST/$DST
+cd $DST
+echo "Adding remote development branch to $DST"
+git remote add vauxoo-dev git@github.com:Vauxoo-dev/$DST
+echo "Switching back to $ROOT_DIR"
+cd $ROOT_DIR
+
+# while IFS='' read -r REPO || [[ -n "$REPO" ]]; do
+#     echo "Checking if Folder $REPO already exists"
+#     if [ -d "$REPO" ]; then
+#         echo "Deleting Folder $REPO"
+#         rm -rf $REPO
+#     fi
+#     echo "Cloning $REPO Project"
+#     git clone git@github.com:Vauxoo/$REPO
+#     cd $REPO
+#     echo "Adding remote development branch to $REPO"
+#     git remote add vauxoo-dev git@github.com:Vauxoo-dev/$REPO
+#     echo "Switching back to $ROOT_DIR"
+#     cd $ROOT_DIR
+# done < "$2"
 
 while IFS='' read -r MODULE || [[ -n "$MODULE" ]]; do
     echo "Module: $MODULE"
@@ -84,6 +96,7 @@ while IFS='' read -r MODULE || [[ -n "$MODULE" ]]; do
 
     echo "Checking out stable branch $VER on $SRC Branch"
     git checkout $VER
+    git pull
     git fetch vauxoo-dev
 
     echo "Checking out to new branch $VER-tmp-$MODULE-$DEV"
@@ -104,10 +117,8 @@ while IFS='' read -r MODULE || [[ -n "$MODULE" ]]; do
 
     echo "Checking out stable branch $VER on $DST Branch"
     git checkout $VER
+    git pull
     git fetch vauxoo-dev
-
-    echo "Checking out to new branch $VER-git-history-$MODULE-$DEV"
-    git checkout -b $VER-git-history-$MODULE-$DEV
 
     echo "Adding local $SRC repo"
     git remote add $SRC ../tmp-$SRC
@@ -115,33 +126,11 @@ while IFS='' read -r MODULE || [[ -n "$MODULE" ]]; do
     echo "Fetching local $SRC repo"
     git fetch $SRC
 
-    echo "Merging history branch from $SRC repo"
+    echo "Merging migrated module history $MODULE to $VER into $DST"
     git merge $SRC/$VER-tmp-$MODULE-$DEV --commit
 
-    echo "Pushing history for $MODULE module to vauxoo-dev/$DST"
-    git push -f vauxoo-dev $VER-git-history-$MODULE-$DEV
-    git fetch vauxoo-dev
-
-    echo "Making a pull request to vauxoo/$DST"
-    title="[ADD] Landing $MODULE module from vauxoo/$DST"
-    body="Related to https://github.com/Vauxoo/$DST/issues/3"
-    head="vauxoo-dev:$VER-git-history-$MODULE-$DEV"
-    base=$VER
-
-    POST="{ \
-                \"title\": \""$title"\", \
-                \"body\": \""$body"\", \
-                \"head\": \""$head"\", \
-                \"base\": \""$base"\" \
-            }"
-    URL=https://api.github.com/repos/vauxoo/$DST/pulls
-    PR="curl -H $AUTH -d '$POST' $URL"
-    eval $PR
-
-    echo "Deleting module branch on $DST Project"
-    git checkout $VER
-    git fetch vauxoo-dev
-    git branch -D $VER-git-history-$MODULE-$DEV
+    echo "Pushing history for $MODULE module to $USR_DST/$DST"
+    git push $USR_DST $VER
 
     echo "Moving inside $ROOT_DIR Folder"
     cd $ROOT_DIR
@@ -149,91 +138,66 @@ while IFS='' read -r MODULE || [[ -n "$MODULE" ]]; do
     echo "Deleting  tmp-$SRC Because after being used is useless"
     rm -rf tmp-$SRC
 
-    echo "Moving inside $SRC to migrate $MODULE"
+    echo "Moving inside $SRC to delete $MODULE"
     cd $SRC
 
     echo "Checking out stable branch $VER on $SRC Branch"
     git checkout $VER
-    git fetch vauxoo-dev
-
-    echo "Checking out to new branch $VER-git-history-$MODULE-$DEV"
-    git checkout -b $VER-git-history-$MODULE-$DEV
 
     echo "Removing $MODULE module from $SRC"
     git rm -rf $MODULE
-    git commit -am "[REM] $MODULE got moved to vauxoo/$DST project"
+    git commit -am "[REM] $MODULE got moved to $USR_DST/$DST project"
 
-    echo "Pushing branch to vauxoo-dev development project"
-    git push -f vauxoo-dev $VER-git-history-$MODULE-$DEV
-    git fetch vauxoo-dev
+    echo "Pushing branch to $USR_SRC project"
+    git push -f $USR_SRC $VER
 
-    echo "Making a pull request to vauxoo/$SRC"
-    title="[REM] Moving $MODULE module from vauxoo/$DST"
-    body="Related to https://github.com/Vauxoo/$SRC/issues/932"
-    head="vauxoo-dev:$VER-git-history-$MODULE-$DEV"
-    base=$VER
+    # echo "Creating DUMMY Pull Request on Affected Projects"
+    # while IFS='' read -r INSTANCE || [[ -n "$INSTANCE" ]]; do
+    #     echo "Instance: $INSTANCE"
 
-    POST="{ \
-                \"title\": \""$title"\", \
-                \"body\": \""$body"\", \
-                \"head\": \""$head"\", \
-                \"base\": \""$base"\" \
-            }"
-    URL=https://api.github.com/repos/vauxoo/$SRC/pulls
-    PR="curl -H $AUTH -d '$POST' $URL"
-    eval $PR
+    #     echo "Switching to $INSTANCE Project"
+    #     cd $ROOT_DIR/$INSTANCE
+    #     git checkout $VER
+    #     git pull
+    #     git fetch vauxoo-dev
 
-    echo "Deleting module branch on $SRC Project"
-    git checkout $VER
-    git fetch vauxoo-dev
-    git branch -D $VER-git-history-$MODULE-$DEV
+    #     echo "Checking out to new branch $VER-git-history-$MODULE-$DEV"
+    #     git checkout -b $VER-git-history-$MODULE-$DEV
 
-    echo "Creating DUMMY Pull Request on Affected Projects"
-    while IFS='' read -r INSTANCE || [[ -n "$INSTANCE" ]]; do
-        echo "Instance: $INSTANCE"
+    #     echo "Adding Dependency on $INSTANCE to $USR_DST/$DST dev branch"
+    #     sed  "/$SRC/d" oca_dependencies.txt > oca_dependencies.bak
+    #     mv oca_dependencies.bak oca_dependencies.txt
+    #     echo "$SRC git@github.com:Vauxoo-dev/$SRC.git $VER-git-history-$MODULE-$DEV" >> oca_dependencies.txt
+    #     echo "$DST git@github.com:Vauxoo-dev/$DST.git $VER-git-history-$MODULE-$DEV" >> oca_dependencies.txt
+    #     git commit -am "[DUMMY] $MODULE got moved to $USR_DST/$DST project"
 
-        echo "Switching to $INSTANCE Project"
-        cd $ROOT_DIR/$INSTANCE
-        git checkout $VER
-        git pull
-        git fetch vauxoo-dev
+    #     echo "Pushing branch to vauxoo-dev development project"
+    #     git push -f vauxoo-dev $VER-git-history-$MODULE-$DEV
+    #     git fetch vauxoo-dev
 
-        echo "Checking out to new branch $VER-git-history-$MODULE-$DEV"
-        git checkout -b $VER-git-history-$MODULE-$DEV
+    #     echo "Making a pull request to vauxoo/$INSTANCE"
+    #     title="[DUMMY] Moving $MODULE module from vauxoo/$SRC"
+    #     body="Related to https://github.com/Vauxoo/$DST/issues/3"
+    #     head="vauxoo-dev:$VER-git-history-$MODULE-$DEV"
+    #     base=$VER
 
-        echo "Adding Dependency on $INSTANCE to Vauxoo/$DST dev branch"
-        sed  "/$SRC/d" oca_dependencies.txt > oca_dependencies.bak
-        mv oca_dependencies.bak oca_dependencies.txt
-        echo "$SRC git@github.com:Vauxoo-dev/$SRC.git $VER-git-history-$MODULE-$DEV" >> oca_dependencies.txt
-        echo "$DST git@github.com:Vauxoo-dev/$DST.git $VER-git-history-$MODULE-$DEV" >> oca_dependencies.txt
-        git commit -am "[DUMMY] $MODULE got moved to vauxoo/$DST project"
+    #     POST="{ \
+    #                 \"title\": \""$title"\", \
+    #                 \"body\": \""$body"\", \
+    #                 \"head\": \""$head"\", \
+    #                 \"base\": \""$base"\" \
+    #             }"
+    #     URL=https://api.github.com/repos/vauxoo/$INSTANCE/pulls
+    #     PR="curl -H $AUTH -d '$POST' $URL"
+    #     eval $PR
 
-        echo "Pushing branch to vauxoo-dev development project"
-        git push -f vauxoo-dev $VER-git-history-$MODULE-$DEV
-        git fetch vauxoo-dev
+    #     echo "Deleting module branch on $INSTANCE Project"
+    #     git checkout $VER
+    #     git fetch vauxoo-dev
+    #     git branch -D $VER-git-history-$MODULE-$DEV
 
-        echo "Making a pull request to vauxoo/$INSTANCE"
-        title="[DUMMY] Moving $MODULE module from vauxoo/$SRC"
-        body="Related to https://github.com/Vauxoo/$DST/issues/3"
-        head="vauxoo-dev:$VER-git-history-$MODULE-$DEV"
-        base=$VER
-
-        POST="{ \
-                    \"title\": \""$title"\", \
-                    \"body\": \""$body"\", \
-                    \"head\": \""$head"\", \
-                    \"base\": \""$base"\" \
-                }"
-        URL=https://api.github.com/repos/vauxoo/$INSTANCE/pulls
-        PR="curl -H $AUTH -d '$POST' $URL"
-        eval $PR
-
-        echo "Deleting module branch on $INSTANCE Project"
-        git checkout $VER
-        git fetch vauxoo-dev
-        git branch -D $VER-git-history-$MODULE-$DEV
-
-    done < "$2"
+    # done < "$2"
 
 done < "$1"
+
 echo 'END'

--- a/git-history-migrate-branch.sh
+++ b/git-history-migrate-branch.sh
@@ -13,11 +13,14 @@
 
 # TOKEN must be created in github / setting / Personal Access Tokens
 
+HOME_DIR=~/
 ROOT_DIR=~/xDev/git
 DST=account
 SRC=addons-vauxoo
 DEV=hbto
 VER=8.0
+TOKEN=$(cat $HOME_DIR/token.txt)
+AUTH="\"""Authorization: token $TOKEN""\""
 
 
 echo "Moving inside $ROOT_DIR Folder"
@@ -76,7 +79,20 @@ while IFS='' read -r MODULE || [[ -n "$MODULE" ]]; do
     git fetch vauxoo-dev
 
     echo "Making a pull request to vauxoo/$DST"
-    hub pull-request -b vauxoo:$VER -h vauxoo-dev:$VER-git-history-$MODULE-$DEV -m "[ADD] Landing $MODULE module from vauxoo/$DST" -i https://github.com/Vauxoo/$DST/issues/3
+    title="[ADD] Landing $MODULE module from vauxoo/$DST"
+    body="Related to https://github.com/Vauxoo/$DST/issues/3"
+    head="vauxoo-dev:$VER-git-history-$MODULE-$DEV"
+    base=$VER
+
+    POST="{ \
+                \"title\": \""$title"\", \
+                \"body\": \""$body"\", \
+                \"head\": \""$head"\", \
+                \"base\": \""$base"\" \
+            }"
+    URL=https://api.github.com/repos/vauxoo/$DST/pulls
+    PR="curl -H $AUTH -d '$POST' $URL"
+    eval $PR
 
     echo "Deleting module branch on $DST Project"
     git checkout $VER
@@ -108,9 +124,22 @@ while IFS='' read -r MODULE || [[ -n "$MODULE" ]]; do
     git fetch vauxoo-dev
 
     echo "Making a pull request to vauxoo/$SRC"
-    hub pull-request -b vauxoo:$VER -h vauxoo-dev:$VER-git-history-$MODULE-$DEV -m "[ADD] Landing $MODULE module from vauxoo/$SRC" -i https://github.com/Vauxoo/$SRC/issues/932
+    title="[REM] Moving $MODULE module from vauxoo/$DST"
+    body="Related to https://github.com/Vauxoo/$SRC/issues/932"
+    head="vauxoo-dev:$VER-git-history-$MODULE-$DEV"
+    base=$VER
 
-    echo "Deleting module branch on Src Project"
+    POST="{ \
+                \"title\": \""$title"\", \
+                \"body\": \""$body"\", \
+                \"head\": \""$head"\", \
+                \"base\": \""$base"\" \
+            }"
+    URL=https://api.github.com/repos/vauxoo/$SRC/pulls
+    PR="curl -H $AUTH -d '$POST' $URL"
+    eval $PR
+
+    echo "Deleting module branch on $SRC Project"
     git checkout $VER
     git fetch vauxoo-dev
     git branch -D $VER-git-history-$MODULE-$DEV
@@ -136,7 +165,20 @@ while IFS='' read -r MODULE || [[ -n "$MODULE" ]]; do
     git fetch vauxoo-dev
 
     echo "Making a pull request to vauxoo/lodigroup"
-    hub pull-request -b vauxoo:$VER -h vauxoo-dev:$VER-git-history-$MODULE-$DEV -m "[DUMMY] Moving $MODULE module from vauxoo/$SRC" -i https://github.com/Vauxoo/$DST/issues/3
+    title="[DUMMY] Moving $MODULE module from vauxoo/$SRC"
+    body="Related to https://github.com/Vauxoo/$DST/issues/3"
+    head="vauxoo-dev:$VER-git-history-$MODULE-$DEV"
+    base=$VER
+
+    POST="{ \
+                \"title\": \""$title"\", \
+                \"body\": \""$body"\", \
+                \"head\": \""$head"\", \
+                \"base\": \""$base"\" \
+            }"
+    URL=https://api.github.com/repos/vauxoo/lodigroup/pulls
+    PR="curl -H $AUTH -d '$POST' $URL"
+    eval $PR
 
     echo "Deleting module branch on Lodigroup Project"
     git checkout $VER

--- a/git-history-migrate-branch.sh
+++ b/git-history-migrate-branch.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+while IFS='' read -r module || [[ -n "$module" ]]; do
+    echo "Module: $module"
+
+    echo "Moving inside xDev Folder"
+    cd ~/xDev/git
+
+    echo "Copying addons-vauxoo"
+    cp -r addons-vauxoo cp_src
+    echo "Moving inside cp_src to migrate $module"
+    cd cp_src/
+
+    echo "Checking out stable branch 8.0 on Source Branch"
+    git checkout 8.0
+
+    echo "Checking out to new branch 8.0-git-history-$module-hbto"
+    git checkout -b 8.0-git-history-$module-hbto
+
+    echo "Rewriting cp_src branch for $module module"
+    git filter-branch --subdirectory-filter $module -- --all
+    mkdir $module
+    git mv -k * $module
+    git commit -am "[GIT] $module Git history"
+
+
+    echo "Moving inside xDev Folder"
+    cd ~/xDev/git
+    echo "Copying vauxoo/account"
+    cp -r vx-account    cp_dst
+    echo "Moving inside cp_dst to migrage $module"
+    cd cp_dst/
+    echo "Checking out to new branch 8.0-git-history-$module-hbto"
+    git checkout -b 8.0-git-history-$module-hbto
+
+    echo "Adding local cp_src repo"
+    git remote add cp_src ../cp_src
+
+    echo "Fetching local cp_src repo"
+    git fetch cp_src
+
+    echo "Merging history branch from cp_src repo"
+    git merge cp_src/8.0-git-history-$module-hbto --commit
+
+    echo "Pushing history for $module module to vauxoo-dev/account"
+    git push vauxoo-dev 8.0-git-history-$module-hbto
+
+    echo "Deleting Source & Destination Folders"
+    cd ..
+    rm -rf cp_src cp_dst
+
+    echo "Copying addons-vauxoo to delete $module module"
+    cp -r addons-vauxoo cp_src
+    echo "Moving inside cp_src to delete $module module"
+    cd cp_src/
+
+    echo "Checking out stable branch 8.0 on Source Branch"
+    git checkout 8.0
+
+    echo "Checking out to new branch 8.0-git-history-$module-hbto"
+    git checkout -b 8.0-git-history-$module-hbto
+
+    echo "Removing $module module from addons-vauxoo"
+    git rm -rf $module
+    git commit -am "[REM] $module got moved to vauxoo/account project"
+
+    echo "Pushing branch to vauxoo-dev development project"
+    git push vauxoo-dev 8.0-git-history-$module-hbto
+
+    echo "Making a pull request to vauxoo/account"
+    hub pull-request -b vauxoo/account:8.0 -m "[ADD] Moving $module module from vauxoo/addons-vauxoo"
+
+    echo "Deleting Source Folder"
+    cd ..
+    rm -rf cp_src
+
+done < "$1"

--- a/git-history-migrate-branch.sh
+++ b/git-history-migrate-branch.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+
+# In order for this script to work you must:
+# - have git installed
+# - have hub installed
+# - configure your hub config file like:
+# ~/.config/hub
+
+# github.com:
+# - user: USER
+#   oauth_token: TOKEN
+#   protocol: https
+
+# TOKEN must be created in github / setting / Personal Access Tokens
+
 while IFS='' read -r module || [[ -n "$module" ]]; do
     echo "Module: $module"
 
@@ -44,6 +58,9 @@ while IFS='' read -r module || [[ -n "$module" ]]; do
     echo "Pushing history for $module module to vauxoo-dev/account"
     git push vauxoo-dev 8.0-git-history-$module-hbto
 
+    echo "Making a pull request to vauxoo/account"
+    hub pull-request -b vauxoo:8.0 -h vauxoo-dev:8.0-git-history-$module-hbto -m "[REM] Landing $module module from vauxoo/addons-vauxoo"
+
     echo "Deleting Source & Destination Folders"
     cd ..
     rm -rf cp_src cp_dst
@@ -67,7 +84,7 @@ while IFS='' read -r module || [[ -n "$module" ]]; do
     git push vauxoo-dev 8.0-git-history-$module-hbto
 
     echo "Making a pull request to vauxoo/account"
-    hub pull-request -b vauxoo/account:8.0 -m "[ADD] Moving $module module from vauxoo/addons-vauxoo"
+    hub pull-request -b vauxoo:8.0 -h vauxoo-dev:8.0-git-history-$module-hbto -m "[ADD] Moving $module module from vauxoo/addons-vauxoo"
 
     echo "Deleting Source Folder"
     cd ..

--- a/git-history-migrate-branch.sh
+++ b/git-history-migrate-branch.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#/Usage: git-history-migrate-branch.sh module-list.txt instance-list.txt
+#/Usage: git-history-migrate-branch.sh module-list.txt Source-repo Destination-repo
 # module-list.txt is a list of odoo modules to be migrated from a project to
 # another. Must be one line per module.
 # instance-list.txt is a list of odoo projects which are affected by the
@@ -17,13 +17,13 @@
 HOME_DIR=/tmp
 ROOT_DIR=$HOME_DIR/branches
 USR_DST=vauxoo
-USR_SRC=hbto
-DST=account
-SRC=addons-vauxoo
+USR_SRC=vauxoo
+SRC=$2
+DST=$3
 DEV=hbto
 VER=8.0
-TOKEN=$(cat $HOME_DIR/token.txt)
-AUTH="\"""Authorization: token $TOKEN""\""
+# TOKEN=$(cat $HOME_DIR/token.txt)
+# AUTH="\"""Authorization: token $TOKEN""\""
 
 echo "Moving inside $HOME_DIR Folder"
 cd $HOME_DIR
@@ -61,21 +61,6 @@ echo "Adding remote development branch to $DST"
 git remote add vauxoo-dev git@github.com:Vauxoo-dev/$DST
 echo "Switching back to $ROOT_DIR"
 cd $ROOT_DIR
-
-# while IFS='' read -r REPO || [[ -n "$REPO" ]]; do
-#     echo "Checking if Folder $REPO already exists"
-#     if [ -d "$REPO" ]; then
-#         echo "Deleting Folder $REPO"
-#         rm -rf $REPO
-#     fi
-#     echo "Cloning $REPO Project"
-#     git clone git@github.com:Vauxoo/$REPO
-#     cd $REPO
-#     echo "Adding remote development branch to $REPO"
-#     git remote add vauxoo-dev git@github.com:Vauxoo-dev/$REPO
-#     echo "Switching back to $ROOT_DIR"
-#     cd $ROOT_DIR
-# done < "$2"
 
 while IFS='' read -r MODULE || [[ -n "$MODULE" ]]; do
     echo "Module: $MODULE"
@@ -151,53 +136,6 @@ while IFS='' read -r MODULE || [[ -n "$MODULE" ]]; do
     echo "Pushing branch to $USR_SRC project"
     git push -f $USR_SRC $VER
 
-    # echo "Creating DUMMY Pull Request on Affected Projects"
-    # while IFS='' read -r INSTANCE || [[ -n "$INSTANCE" ]]; do
-    #     echo "Instance: $INSTANCE"
-
-    #     echo "Switching to $INSTANCE Project"
-    #     cd $ROOT_DIR/$INSTANCE
-    #     git checkout $VER
-    #     git pull
-    #     git fetch vauxoo-dev
-
-    #     echo "Checking out to new branch $VER-git-history-$MODULE-$DEV"
-    #     git checkout -b $VER-git-history-$MODULE-$DEV
-
-    #     echo "Adding Dependency on $INSTANCE to $USR_DST/$DST dev branch"
-    #     sed  "/$SRC/d" oca_dependencies.txt > oca_dependencies.bak
-    #     mv oca_dependencies.bak oca_dependencies.txt
-    #     echo "$SRC git@github.com:Vauxoo-dev/$SRC.git $VER-git-history-$MODULE-$DEV" >> oca_dependencies.txt
-    #     echo "$DST git@github.com:Vauxoo-dev/$DST.git $VER-git-history-$MODULE-$DEV" >> oca_dependencies.txt
-    #     git commit -am "[DUMMY] $MODULE got moved to $USR_DST/$DST project"
-
-    #     echo "Pushing branch to vauxoo-dev development project"
-    #     git push -f vauxoo-dev $VER-git-history-$MODULE-$DEV
-    #     git fetch vauxoo-dev
-
-    #     echo "Making a pull request to vauxoo/$INSTANCE"
-    #     title="[DUMMY] Moving $MODULE module from vauxoo/$SRC"
-    #     body="Related to https://github.com/Vauxoo/$DST/issues/3"
-    #     head="vauxoo-dev:$VER-git-history-$MODULE-$DEV"
-    #     base=$VER
-
-    #     POST="{ \
-    #                 \"title\": \""$title"\", \
-    #                 \"body\": \""$body"\", \
-    #                 \"head\": \""$head"\", \
-    #                 \"base\": \""$base"\" \
-    #             }"
-    #     URL=https://api.github.com/repos/vauxoo/$INSTANCE/pulls
-    #     PR="curl -H $AUTH -d '$POST' $URL"
-    #     eval $PR
-
-    #     echo "Deleting module branch on $INSTANCE Project"
-    #     git checkout $VER
-    #     git fetch vauxoo-dev
-    #     git branch -D $VER-git-history-$MODULE-$DEV
-
-    # done < "$2"
-
 done < "$1"
 
-echo 'END'
+

--- a/git-shrinking-repo.sh
+++ b/git-shrinking-repo.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+#/Usage: git-history-migrate-branch.sh module-list.txt instance-list.txt
+# module-list.txt is a list of odoo modules to be migrated from a project to
+# another. Must be one line per module.
+# instance-list.txt is a list of odoo projects which are affected by the
+# migration of this modules. Must be one line per instance.
+# token.txt must be located on $HOME_DIR
+# To create TOKEN you must go to github.com / Settings / Personal Access Token
+# and create a new one. Beware: TOKEN is like a password so it be kept safe.
+
+# This could be helpful for rewriting history on project
+# https://developer.atlassian.com/blog/2015/08/grafting-earlier-history-with-git/
+
+# Scripted by:
+# Humberto Arocha <hbto@vauxoo.com>
+
+HOME_DIR=/tmp
+ROOT_DIR=$HOME_DIR/branches
+USR_DST=vauxoo
+USR_SRC=hbto
+DST=account
+SRC=addons-vauxoo
+DEV=hbto
+VER=8.0
+TOKEN=$(cat $HOME_DIR/token.txt)
+AUTH="\"""Authorization: token $TOKEN""\""
+FILEDIR_LIST=""
+
+echo "Moving inside $HOME_DIR Folder"
+cd $HOME_DIR
+
+if [ ! -d "$ROOT_DIR" ]; then
+    echo "Creating Folder $ROOT_DIR"
+    mkdir -p $ROOT_DIR
+fi
+
+echo "Moving inside $ROOT_DIR Folder"
+cd $ROOT_DIR
+
+echo "Checking if Folder $SRC already exists"
+if [ -d "$SRC" ]; then
+    echo "Deleting Folder $SRC"
+    rm -rf $SRC
+fi
+echo "Cloning $SRC Project"
+git clone git@github.com:$USR_SRC/$SRC
+
+cd $SRC
+
+echo "Adding remote development branch to $DST"
+git remote add vauxoo-dev git@github.com:Vauxoo-dev/$DST
+
+while IFS='' read -r MODULE || [[ -n "$MODULE" ]]; do
+    echo "File/Directory to Delete: $MODULE"
+    FILEDIR_LIST+=" $MODULE"
+done < "$1"
+
+echo "Cleaning the files"
+echo "Cleaning the file will take a while, depending on how busy your repository has been."
+FILTER_CMD="git filter-branch --tag-name-filter cat --index-filter ""'""git rm -r --cached --ignore-unmatch $FILEDIR_LIST""'"" --prune-empty -f -- --all"
+eval $FILTER_CMD
+
+echo "Reclaiming space"
+rm -rf .git/refs/original/
+git reflog expire --expire=now --all
+git gc --prune=now
+git gc --aggressive --prune=now
+
+echo '*** END ***'


### PR DESCRIPTION
This PR provides a script that allows to migrate
modules from one project to another by:
- Taking Git history of module and creating a new branch in Destination Project.
- Creating a PR for history on Destination project
- Creating a new branch for getting rid of module on Source project.
- Creating a PR of module being got rid.
- Modifying oca_requirements.txt file on affected projects and adding new branches
  of Source (without module) and Destination (with module) and Creating regarding PR.
