### PR TITLE
No module named oerplib in odoo-i18n-export

### DIFF
--- a/odoo-i18n-export/install
+++ b/odoo-i18n-export/install
@@ -1,4 +1,7 @@
 #!/bin/bash
+pip install oerplib
+pip install argparse
+pip install argcomplete
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}"  )" && pwd  )"
 echo "alias odoo-i18n-export='${DIR}/odoo-i18n-export.py'" >> ${HOME}/.profile
 source ${HOME}/.profile


### PR DESCRIPTION
When I execute the `odoo-i18n-export` command line it shows me this error:

```
$ odoo-i18n-export 
Traceback (most recent call last):
  File "/root/tools/gist-vauxoo/odoo-i18n-export/odoo-i18n-export.py", line 9, in <module>
    import oerplib
ImportError: No module named oerplib
```

Making `pip install oerplib` fix this problem, but maybe it should be a job to do in the `./install` script.