### PR TITLE
Permission denied trying to execute odoo-i18n-export

### DIFF
--- a/odoo-i18n-export/install
+++ b/odoo-i18n-export/install
@@ -3,5 +3,5 @@ pip install oerplib
 pip install argparse
 pip install argcomplete
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}"  )" && pwd  )"
-echo "alias odoo-i18n-export='${DIR}/odoo-i18n-export.py'" >> ${HOME}/.profile
+echo "alias odoo-i18n-export='python ${DIR}/odoo-i18n-export.py'" >> ${HOME}/.profile
 source ${HOME}/.profile


### PR DESCRIPTION
I recently installed the tool `odoo-i18n-export` but when I try to execute it, says that I have no permission to do it.

```
$ odoo-i18n-export 
-bash: /root/tools/gist-vauxoo/odoo-i18n-export/odoo-i18n-export.py: Permission denied
```

I fix it giving that script the execution bit

```
$ chmod +x odoo-i18n-export.py
```

But I think it should have execution permissions once the container is created.