### PR TITLE
[IMP] odoo-instance: apply git clean after pulling new changes

### DIFF
--- a/odoo-instance/odoo-instance
+++ b/odoo-instance/odoo-instance
@@ -255,6 +255,7 @@ class OerpInstance(object):
             self.print_repo_data(repo, branch)
             os.system('cd {path} && git log --oneline -1'.format(path=path))
             os.system('cd {path} && git pull'.format(path=path))
+            os.system('cd {path} && git clean -xdf'.format(path=path))
         return True
 
     def paths_instance(self):


### PR DESCRIPTION
When modules are removed from the git repo, i.e. stop tracking changes from it, the directory may still exists after a `git pull` is done and this may cause non-expected behavior. So it is necessary to apply a `git clean` after the `git pull` have been taken place
