### PR TITLE
[FIX] odoo-instance: misspelling in repository name

### DIFF
--- a/odoo-instance/vauxoo.json
+++ b/odoo-instance/vauxoo.json
@@ -91,7 +91,7 @@
         "path": "/root/odoo-ifrs",
         "branch": "8.0"
     },
-    "Vauxoo/odoo-afrs/8.0": {
+    "Vauxoo/odoo-afr/8.0": {
         "path": "/root/odoo-afrs",
         "branch": "8.0"
     },


### PR DESCRIPTION
odoo-afrs do not exist, odoo-afr it does.