### PR TITLE
[ADD] stock_diagnosis: Scripts to detect discrepancies by quants and moves

### DIFF
--- a/stock_diagnosis/quants_differ_all_stock_moves.sql
+++ b/stock_diagnosis/quants_differ_all_stock_moves.sql
@@ -1,0 +1,73 @@
+/*
+This retrieves the products and their internal locations whose quantity
+reported by their quants is different from the sum of all their stock moves
+(incoming moves - outgoing moves).
+
+This is achieved by:
+1) Retrieve product quantities by location according to quants
+2) Retrieve incoming stock moves by location
+3) Retrieve outgoing stock moves by location
+4) Compare results of the previous steps, showing only those when 1) is 
+   different from 2) - 3)
+*/
+WITH quant_quantity AS (
+    SELECT  
+        product_id,
+        location_id,
+        SUM(quantity)::NUMERIC AS sum_qty
+    FROM
+        stock_quant
+    GROUP BY
+        product_id,
+        location_id
+),
+in_move_quantity AS (
+    SELECT
+        product_id,
+        location_dest_id AS location_id,
+        SUM(product_uom_qty)::NUMERIC AS sum_qty
+    FROM
+        stock_move
+    WHERE
+        location_id != location_dest_id
+    GROUP BY
+        product_id,
+        location_dest_id
+),
+out_move_quantity AS (
+    SELECT
+        product_id,
+        location_id,
+        -SUM(product_uom_qty)::NUMERIC AS sum_qty
+    FROM
+        stock_move
+    WHERE
+        location_id != location_dest_id
+    GROUP BY
+        product_id,
+        location_id
+)
+SELECT
+    q.product_id,
+    q.location_id,
+    q.sum_qty AS qty_on_quants,
+    m_in.sum_qty AS qty_on_incoming_moves,
+    m_out.sum_qty AS qty_on_outgoing_moves,
+    m_in.sum_qty + m_out.sum_qty AS qty_on_all_moves,
+    q.sum_qty - (m_in.sum_qty + m_out.sum_qty) AS difference
+FROM
+    quant_quantity AS q
+INNER JOIN
+    in_move_quantity AS m_in
+    ON q.product_id = m_in.product_id
+    AND q.location_id = m_in.location_id
+LEFT OUTER JOIN
+    out_move_quantity AS m_out
+    ON q.product_id = m_out.product_id
+    AND q.location_id = m_out.location_id
+INNER JOIN
+    stock_location AS sl
+    ON q.location_id = sl.id
+WHERE
+    q.sum_qty != (m_in.sum_qty + m_out.sum_qty)
+    AND sl.usage = 'internal';

--- a/stock_diagnosis/quants_differ_logistic_qty.sql
+++ b/stock_diagnosis/quants_differ_logistic_qty.sql
@@ -1,0 +1,50 @@
+/*
+This retrieves the products and their internal locations whose quantity
+reported by their quants is greater than the sum of all logistic quantities
+re ported by stock moves, in case the module `stock_cost_segmentation` is
+installed [1].
+
+This is achieved by:
+1) Retrieve product quantities by location according to quants
+2) Retrieve logistic quantities by location
+3) Compare results of the previous steps, showing only those when 1) is 
+   different from 2)
+
+[1] https://github.com/Vauxoo/addons-vauxoo/tree/11.0/stock_cost_segmentation
+*/
+WITH quant_quantity AS (
+    SELECT  
+        product_id,
+        location_id,
+        SUM(quantity)::NUMERIC AS sum_qty
+    FROM
+        stock_quant
+    GROUP BY
+        product_id,
+        location_id
+),
+logistic_quantity AS (
+    SELECT
+        product_id,
+        location_dest_id AS location_id,
+        SUM(logistic_remaining_qty)::NUMERIC AS sum_qty
+    FROM
+        stock_move
+    GROUP BY
+        product_id,
+        location_dest_id
+)
+SELECT
+    q.product_id,
+    q.location_id,
+    q.sum_qty AS qty_on_quants,
+    l.sum_qty AS logistic_qty_on_moves,
+    q.sum_qty -     l.sum_qty AS difference
+FROM
+    quant_quantity AS q
+INNER JOIN
+    logistic_quantity AS l
+    ON q.product_id = l.product_id
+    AND q.location_id = l.location_id
+WHERE
+    q.sum_qty != l.sum_qty;

--- a/stock_diagnosis/quants_greater_in_stock_moves.sql
+++ b/stock_diagnosis/quants_greater_in_stock_moves.sql
@@ -1,0 +1,52 @@
+/*
+This retrieves the products and their internal locations whose quantity
+reported by their quants is greater than the sum of all incoming stock moves.
+
+This is achieved by:
+1) Retrieve product quantities by location according to quants
+2) Retrieve incoming stock moves by location
+3) Compare results of the previous steps, showing only those when 1) is greater
+   than 2)
+*/
+WITH quant_quantity AS (
+    SELECT  
+        product_id,
+        location_id,
+        SUM(quantity)::NUMERIC AS sum_qty
+    FROM
+        stock_quant
+    GROUP BY
+        product_id,
+        location_id
+),
+in_move_quantity AS (
+    SELECT
+        product_id,
+        location_dest_id AS location_id,
+        SUM(product_uom_qty)::NUMERIC AS sum_qty
+    FROM
+        stock_move
+    WHERE
+        location_id != location_dest_id
+    GROUP BY
+        product_id,
+        location_dest_id
+)
+SELECT
+    q.product_id,
+    q.location_id,
+    q.sum_qty AS qty_on_quants,
+    m.sum_qty AS qty_on_incoming_moves,
+    q.sum_qty - m.sum_qty AS difference
+FROM
+    quant_quantity AS q
+INNER JOIN
+    in_move_quantity AS m
+    ON q.product_id = m.product_id
+    AND q.location_id = m.location_id
+INNER JOIN
+    stock_location AS sl
+    ON q.location_id = sl.id
+WHERE
+    q.sum_qty > m.sum_qty
+    AND sl.usage = 'internal';


### PR DESCRIPTION
The following scripts are added:
- `quants_greater_in_stock_moves.sql`: detect differences between quants
  and incoming stock moves
- `quants_differ_all_stock_moves.sql` detect differences between quants
  and all stock moves (incoming and outgoing)
- `quants_differ_logistic_qty.sql`: detect differences between quants
  and logistic quantities, when the module `stock_cost_segmentation` [1]
  is installed

For more information, check the documentation on the mentioned scripts.

[1] https://github.com/Vauxoo/addons-vauxoo/tree/11.0/stock_cost_segmentation