### PR TITLE
[FIX] stock_diagnosis: Consider only internal locations on logistic qtys

### DIFF
--- a/stock_diagnosis/quants_differ_logistic_qty.sql
+++ b/stock_diagnosis/quants_differ_logistic_qty.sql
@@ -46,5 +46,9 @@ INNER JOIN
     logistic_quantity AS l
     ON q.product_id = l.product_id
     AND q.location_id = l.location_id
+INNER JOIN
+    stock_location AS sl
+    ON q.location_id = sl.id
 WHERE
-    q.sum_qty != l.sum_qty;
+    q.sum_qty != l.sum_qty
+    AND sl.usage = 'internal';


### PR DESCRIPTION
All location types were being considered, which caused false positives.