### PR TITLE
[FIX] stock_diagnosis: False positives due to rounding

### DIFF
--- a/stock_diagnosis/quants_differ_all_stock_moves.sql
+++ b/stock_diagnosis/quants_differ_all_stock_moves.sql
@@ -119,6 +119,6 @@ LEFT OUTER JOIN
     out_move_quantity AS m_out
     USING(product_id, location_id, lot_id, package_id, owner_id, company_id)
 WHERE
-    q.sum_qty != COALESCE(m_in.sum_qty, 0.0) - COALESCE(m_out.sum_qty, 0.0)
+    ROUND(q.sum_qty - (COALESCE(m_in.sum_qty, 0.0) - COALESCE(m_out.sum_qty, 0.0)), 2) != 0.0
 ORDER BY
     COALESCE(m_in.sml_count, 0) + COALESCE(m_out.sml_count, 0);


### PR DESCRIPTION
Sometimes there are very small differences that should not be considered
because, when rounded, they disappear.