### PR TITLE
[FIX] ir_module_module_extract_installed: don't exclude EDI modules

### DIFF
--- a/ir_module_module_extract_installed.py
+++ b/ir_module_module_extract_installed.py
@@ -1,14 +1,14 @@
 # Server action to output all modules to be included on the manifest, useful
 # when initializing a module for an app of an already-existing instance,
-# or when removing superfluous modules
+# or when removing superfluous dependencies
 
 MODNAMES_TO_ADD = []
 # Add here app's module name if already installed, so its dependencies are not considered
 MODNAMES_TO_IGNORE = [
-    # All modules dependn on base anyway
+    # All modules depend on base anyway
     "base",
     # Don't install it unless necessary, to avoid performance issues
-    # If there's no data for it, then it dosen't make sense to have it in CI
+    # If there's no data for it, then it doesn't make sense to have it in CI
     "base_automation",
     # Dependency of OdooStudio, not useful in CI
     "base_import_module",
@@ -37,7 +37,10 @@ def compute_dependencies(modules):
 module_obj = env['ir.module.module'].sudo()
 installed_modules = module_obj.search([
     ('state', '=', 'installed'),
+    '|',
     ('auto_install', '=', False),
+    # l10n_mx_edi is marked as autoinstall, but it should be added anyway
+    ('category_id.name', '=', 'EDI'),
     ('name', 'not in', MODNAMES_TO_IGNORE),
 ])
 


### PR DESCRIPTION
l10n_mx_edi is marked as autoinstall, but it should be added anyway.