### PR TITLE
[FIX] generate_module_dependency_priority: don't discard last level t#57540

### DIFF
--- a/generate_module_dependency_priority.py
+++ b/generate_module_dependency_priority.py
@@ -16,9 +16,10 @@ for x in range(20):
         - module_base
     )
     current_level -= new_level
+    levels.append(current_level)
     if not new_level:
         break
-    levels.extend([current_level, new_level])
+    levels.append(new_level)
 
 # Exclude native modules from result
 native_modules = module_base.search([("author", "=", "Odoo S.A."), ("state", "=", "installed")])


### PR DESCRIPTION
Whenever a level is processed, it's popped , then modified and re-inserted. However, last level wasn't being re-inserted.