### PR TITLE
[IMP] gitlab_api: several improvements t#58355

### DIFF
--- a/gitlab_mr_template/ci_missing_tags-luisg/.gitlab-ci.yml
+++ b/gitlab_mr_template/ci_missing_tags-luisg/.gitlab-ci.yml
@@ -1,0 +1,10 @@
+{%- set lines = self_file.splitlines() %}
+{%- set odoo_tag = lines.index("  stage: test") +2 %}
+{%- set _ = lines.__setitem__(odoo_tag, lines[odoo_tag].replace("- build", "- odoo")) %}
+{%- for job in ("publish_coverage", "odoo_warnings") %}
+    {%- set job_tags = lines.index("%s:" % job) +3 %}
+    {%- if "tags:" not in lines[job_tags] %}
+        {%- set _ = lines.insert(job_tags, "  tags:\n    - build")  %}
+    {%- endif %}
+{%- endfor %}
+{{ "\n".join(lines) }}


### PR DESCRIPTION
The following improvements are included:
- Create MR pushing from dev project whenever possible (e.g. vauxoo-dev)
- Include description also in commit, not only in MR
- Ensure source branch is deleted when the MR is merged, even if it's not the default behavior
- Allow to specify task ID for MR's title
- Make configurable whether version name will be prefixed to MR's title
- Don't prefix version name into resulting commit, only in MR