### PR TITLE
[FIX] gitlab_api: error when creating MR with sub-directories t#63281

### DIFF
--- a/gitlab_api.py
+++ b/gitlab_api.py
@@ -313,7 +313,9 @@ class GitlabAPI(object):
                             content = tmpl.render(tmpl_data).strip("\n") + "\n"
                             if len(content) == 1 and content == "\n":
                                 content = ""
-                            with open(os.path.join(git_work_tree, fname_tmpl), "w") as fobj:
+                            fname_out = os.path.join(git_work_tree, fname_tmpl)
+                            os.makedirs(os.path.dirname(fname_out), exist_ok=True)
+                            with open(fname_out, "w") as fobj:
                                 fobj.write(content)
                             cmd = git_cmd + ["add", fname_tmpl]
                             subprocess.check_call(cmd)


### PR DESCRIPTION
When creating an MR for a file contained into a sub-directory, if the directory doesn't exist yet, file creation fails.