### PR TITLE
[IMP] gitlab_api: only use fix in pre-commit-vauxoo T#61194

### DIFF
--- a/gitlab_api.py
+++ b/gitlab_api.py
@@ -373,7 +373,7 @@ class GitlabAPI:
                         subprocess.check_call(cmd)
                         mr_title = "%s - %s" % (branch.name, title) if prefix_version else title
                         if task_id:
-                            mr_title += " t#%s" % task_id
+                            mr_title += " T#%s" % task_id
                         mr = project_dev.mergerequests.create(
                             {
                                 "target_project_id": project.id,

--- a/gitlab_api.py
+++ b/gitlab_api.py
@@ -356,9 +356,9 @@ class GitlabAPI:
                             # Use py3.8.10 to match with dockerv image
                             with chdir(git_work_tree):
                                 runner = CliRunner()
-                                runner.invoke(pcv_cli.main, [])
+                                runner.invoke(pcv_cli.main, ["-t", "fix"])
                                 # Call 2 times to fix conflicts with multiple autofixes
-                                runner.invoke(pcv_cli.main, [])
+                                runner.invoke(pcv_cli.main, ["-t", "fix"])
                         git_cmd_diff = git_cmd + ["--no-pager", "diff", "--no-ext-diff", "--name-only"]
                         diff = subprocess.check_output(git_cmd_diff).strip(b"\n ")[:1]
                         diff += subprocess.check_output(git_cmd_diff + ["--cached"]).strip(b"\n ")[:1]


### PR DESCRIPTION
To save time when calling pre-commit-vauxoo, just use the hook type "fix".