### PR TITLE
[IMP] gitlab_api: changes to run autoformatter for translations T#61194

### DIFF
--- a/run_po_autoformatter.py
+++ b/run_po_autoformatter.py
@@ -1,0 +1,30 @@
+from gitlab_api import GitlabAPI
+
+projects_branches = [
+    "vauxoo/sbd@14.0",
+]
+commit_msg = """
+[I18n] $module: autoformat translations
+
+This runs the translations autoformatter [1], which performs the
+following changes over .po files:
+- Sort terms alphabetically
+- Split lines to 78 characters
+- clear message when translated term is the same as original one
+
+This is done to produce a file as if it were re-exported from Odoo. For
+more info, see [2].
+
+[1] https://github.com/OCA/odoo-pre-commit-hooks/pull/76  
+[2] https://github.com/Vauxoo/pre-commit-vauxoo/issues/104
+"""
+
+gl = GitlabAPI()
+gl.make_mr(
+    projects_branches=projects_branches,
+    commit_msg=commit_msg,
+    branch_dev_name="i18n_autoformat-luisg",
+    task_id=61194,
+    prefix_version=True,
+    run_pre_commit_vauxoo=True,
+)


### PR DESCRIPTION
Some changes to be able to run the autoformatter [1]:
- Skip repo if no translation files were modified
- Create one commit per module
- Add a script to run the GitLab API class

[1] https://github.com/OCA/odoo-pre-commit-hooks/pull/76