### PR TITLE
[ADD] initialize_team_reviewers: script to init new GitLab team T#84147

### DIFF
--- a/gitlab_mr_template/gitignore_oca_hooks-luisg/.gitignore
+++ b/gitlab_mr_template/gitignore_oca_hooks-luisg/.gitignore
@@ -1,0 +1,87 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+*.DS_Store*
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+bin/
+build/
+develop-eggs/
+dist/
+eggs/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coveragerc
+.coverage.*
+et
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+
+# Pycharm
+.idea
+
+# VS Code
+.vscode
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# Rope
+.ropeproject
+
+# Sphinx documentation
+docs/_build/
+
+# Backup files
+*~
+*.swp
+
+# docker JSON packages
+package-lock.json
+package.json
+
+# docker node_modules
+node_modules/
+
+# pre-commit-vauxoo
+.bandit*
+.config/
+.editorconfig
+.eslintrc*
+.flake8*
+.isort.cfg
+.oca_hooks*
+.pre-commit*.yaml
+.prettierrc.yml
+.pylintrc*
+bandit*.yaml
+doc8.ini
+pyproject.toml

--- a/initialize_team_reviewers.py
+++ b/initialize_team_reviewers.py
@@ -1,0 +1,41 @@
+import os
+
+import gitlab
+
+GITLAB_CFG = os.path.expanduser("~/.python-gitlab.cfg")
+
+
+# Connect to GitLab instance
+gl = gitlab.Gitlab.from_config("default", [GITLAB_CFG])
+
+# Retrieve groups
+group_reviewers = gl.groups.get("teams/reviewers")
+group_developers = gl.groups.get("teams/developers")
+all_groups = gl.groups.list(all=True)
+
+# Grant developer access to the reviewers team in all groups that the developers team already have access
+for group in all_groups:
+    group = gl.groups.get(group.id)
+    if any(g["group_full_path"] == group_developers.full_path for g in group.shared_with_groups):
+        print(group.full_path)
+        try:
+            group.share(group_reviewers.id, group_access=gitlab.const.AccessLevel.DEVELOPER)
+        except Exception as err:
+            print(err)
+
+# Remove direct access to reviewers to projects, because access is now implicit
+reviewer_members = group_reviewers.members.list(all=True)
+reviewer_member_ids = {m.id for m in reviewer_members}
+# all_projects = gl.projects.list(all=True)
+for project in all_projects:
+    removed_this_project = []
+    for member in project.members.list(all=True):
+        if member.id in reviewer_member_ids:
+            try:
+                member.delete()
+            except Exception as err:
+                print("Couldn't delete %s from %s: %s" % (member.username, project.name_with_namespace, err))
+                continue
+            removed_this_project.append(member.username)
+    if removed_this_project:
+        print("%s: %s" % (project.name_with_namespace, ", ".join(removed_this_project)))


### PR DESCRIPTION
This new group will be in charge of reviewing code from developers.

This script does the following:
- Grant developer access to all groups on which the "teams/developers" group was already granted access to.
- Remove direct membership of reviewers from all projects, as acces is now granted through the new group.