### PR TITLE
[IMP] installed_custom_modules: consider authors case insensitive T#86041

### DIFF
--- a/installed_custom_modules.py
+++ b/installed_custom_modules.py
@@ -9,7 +9,7 @@ env.cr.execute(
         ir_module_module
     WHERE
         state = 'installed'
-        AND author NOT IN ('Odoo S.A.', 'Odoo SA', 'Odoo')
+        AND LOWER(author) NOT IN ('odoo s.a.', 'odoo sa', 'odoo')
         -- CoA modules are generally not authored by Odoo
         AND name NOT LIKE 'l10n\\___'
     ORDER BY


### PR DESCRIPTION
Some modules like `html_editor` have "odoo" (lowercase) as author [1], so we need to consider authors on a case-insensitive manner.

[1]: https://github.com/odoo/odoo/pull/190655