### PR TITLE
[FIX] ir_module_module_extract_installed: don't consider test modules T#89440

### DIFF
--- a/ir_module_module_extract_installed.py
+++ b/ir_module_module_extract_installed.py
@@ -37,6 +37,7 @@ def compute_dependencies(modules):
 module_obj = env['ir.module.module'].sudo()
 installed_modules = module_obj.search([
     ('state', '=', 'installed'),
+    ('category_id.name', '!=', 'Tests'),
     '|',
     ('auto_install', '=', False),
     # l10n_mx_edi is marked as autoinstall, but it should be added anyway


### PR DESCRIPTION
When extracting installed modules, test modules shouldn't be considered, even if they're installed in production.