### PR TITLE
[IMP] installed_custom_modules: new criteria to determine native modules T#86043

### DIFF
--- a/installed_custom_modules.py
+++ b/installed_custom_modules.py
@@ -1,5 +1,18 @@
 # Server action to output all installed modules that are not native, i.e. not maintained by Odoo S.A.
-# This is usefuld to be used to fill the whitelist of modules to keep in post SQL migration scripts.
+# This is usefuld to be used to fill the whitelist of modules to keep in cleaning migration scripts.
+
+# Known authors used by native modules, in most cases it's Odoo S.A.
+NATIVE_MODULE_AUTHORS = {"Odoo S.A.", "odoo S.A", "Odoo SA", "Odoo"}
+
+# Known native modules whose author is not Odoo, e.g. l10n_mx_reports is authored by Vauxoo
+NATIVE_MODULES_DIFF_AUTHOR = {
+    "l10n_latam_check",
+    "l10n_latam_invoice_document",
+    "l10n_mx_reports",
+    "l10n_pe_edi",
+    "l10n_pe_edi_stock",
+    "l10n_pe_reports",
+}
 
 env.cr.execute(
     """
@@ -9,12 +22,23 @@ env.cr.execute(
         ir_module_module
     WHERE
         state = 'installed'
-        AND LOWER(author) NOT IN ('odoo s.a.', 'odoo sa', 'odoo')
+        AND latest_version IS NOT NULL
+        AND NOT (
+            STRING_TO_ARRAY(
+                LOWER(regexp_replace(author, ', | / ', ',', 'g')),
+                ','
+            ) && %(native_module_authors)s
+        )
         -- CoA modules are generally not authored by Odoo
         AND name NOT LIKE 'l10n\\___'
+        AND name NOT IN %(native_modules_diff_author)s
     ORDER BY
         name;
-    """
+    """,
+    {
+        "native_module_authors": [a.lower() for a in NATIVE_MODULE_AUTHORS],
+        "native_modules_diff_author": tuple(NATIVE_MODULES_DIFF_AUTHOR),
+    },
 )
 installed_modules = [x[0] for x in env.cr.fetchall()]
 result_str = ",\n".join("'%s'" % module for module in installed_modules)


### PR DESCRIPTION
To determine whether a module is native, new criteria are added:
- Consider modules we know in advance are native but whose author in the manifest is not Odoo, e.g. l10n_mx_reports is authored by Vauxoo
- Consider other variations of "Odoo S.A." that are also used as module authors, e.g. "Odoo SA".